### PR TITLE
Adding a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ If you are looking for the source code of the [React Native Archive website](htt
 
 1.  `cd website` to go into the website portion of the project.
 1.  `yarn start` to start the development server _(powered by [Docusaurus](https://v2.docusaurus.io))_.
+    **_Note: In case you find any error regarding [Docusaurus], while starting the development server, run the command `yarn upgrade docusaurus --latest`._**
 1.  `open http://localhost:3000/` to open the site in your favorite browser.
 
 ## 📖 Overview

--- a/README.md
+++ b/README.md
@@ -25,13 +25,12 @@ If you are looking for the source code of the [React Native Archive website](htt
 ### Installation
 
 1.  `cd react-native-website` to go into the project root.
-1.  `yarn` to install the website's workspace dependencies.
+1.  Run `yarn` to install the website's workspace dependencies.
 
 ### Running locally
 
 1.  `cd website` to go into the website portion of the project.
 1.  `yarn start` to start the development server _(powered by [Docusaurus](https://v2.docusaurus.io))_.
-    **_Note: In case you find any error regarding [Docusaurus], while starting the development server, run the command `yarn upgrade docusaurus --latest`._**
 1.  `open http://localhost:3000/` to open the site in your favorite browser.
 
 ## 📖 Overview


### PR DESCRIPTION
While starting the server , I found 'docusaurus' is not recognized as an internal or external command, operable program or batch file .  It took me some time to find the solution and found this command on stackoverflow. If included here, the command might help the user in dealing with such problems and it will save the user's time.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
